### PR TITLE
Chore: Make CodeCov ignore UI code

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,2 @@
+ignore:
+  - "seedu/address/ui/**/*.java"


### PR DESCRIPTION
Testing for UI components is tedious and is not compulsory for this project. However, maintaining a consistently high code coverage is a requirement for this project.

Therefore, let's make CodeCov ignore the UI code to avoid having a low code coverage.

Fixes #82 