### PR TITLE
Chore: Make codecov ignore ui files

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,2 +1,2 @@
 ignore:
-  - "seedu/address/ui/**/*.java"
+  - "**/address/ui/**/*.java"


### PR DESCRIPTION
Fixes #138 

@kenghow's #128 reveals an issue with the codecov.yml file, as it seems UI files `**/seedu/java/ui/**/*.java` are still considered for code coverage.

Upon checking codecov [documentation](https://docs.codecov.com/docs/ignoring-paths), it is noted that we need to set the file path from the repo root, not just from the java module root.

Current:
```
ignore:
  - seedu/address/ui/**/*.java
```

To update:
```
ignore:
  - "**/address/ui/**/*.java"
```
