### PR TITLE
Bug: Fix Find Command GUI tag validation issue

### DIFF
--- a/src/main/java/seedu/address/ui/FilterPanel.java
+++ b/src/main/java/seedu/address/ui/FilterPanel.java
@@ -85,13 +85,12 @@ public class FilterPanel extends UiPart<Region> {
     }
 
     /**
-     * Binds a filter field to its respective keywords, extracted from {@link ReadOnlyFilterDetails}.
+     * Binds a Filter Panel field to the keywords it is supposed to display
      *
      * <p>When users edit tags in the field, this method sets the {@link ReadOnlyFilterDetails} via
      * {@link #applyKeywordsAndExecuteFilter(KeywordSetter, ObservableSet, Set)}.
      *
-     * <p>When {@code sourceKeywords} changes from elsewhere, this method updates the field UI through a listener so
-     * both UI and Model stay synchronized.
+     * <p>When {@code sourceKeywords} are changes from logic or model, the field UI is updated through a listener
      *
      * @param placeholder   target UI container
      * @param title         section label
@@ -104,8 +103,7 @@ public class FilterPanel extends UiPart<Region> {
         FilterPanelField field = new FilterPanelField(
                 title,
                 promptText,
-                // Every field has a {@code KeywordSetter} which applies the new keywords to a copied FilterDetails
-                // and execute filtering
+                // When the field updates, apply the change and execute filtering with the new keywords
                 keywords -> applyKeywordsAndExecuteFilter(
                         keywordSetter,
                         sourceKeywords,
@@ -114,19 +112,17 @@ public class FilterPanel extends UiPart<Region> {
         field.setKeywords(List.copyOf(sourceKeywords));
         placeholder.getChildren().setAll(field.getRoot());
 
-        // Listen for changes in the source keyword set and update the field accordingly
+        // Listen for changes in the source keyword set and update the field UI accordingly
         sourceKeywords.addListener((SetChangeListener<? super String>) ignoredChange ->
                 field.setKeywords(List.copyOf(sourceKeywords)));
     }
 
     /**
-     * Applies one field type update to a fresh {@link FilterDetails} copy and executes filtering.
+     * Applies one field type update to a fresh {@link FilterDetails} copy then executes filtering.
      *
-     * @param keywordSetter   strategy that updates exactly one keyword set in the copied details.
-     * @param updatedKeywords user-edited keywords for the target field.
+     * @param keywordSetter   method that sets old Filter Details keywords to new ones
+     * @param updatedKeywords updated keywords from UI
      *
-     *                        <p>This method preserves untouched field by copying from the current read-only
-     *                        details first, then mutating only the requested field via {@code keywordSetter}.
      */
     private List<String> applyKeywordsAndExecuteFilter(
             KeywordSetter keywordSetter,

--- a/src/main/java/seedu/address/ui/filter/FilterPanelField.java
+++ b/src/main/java/seedu/address/ui/filter/FilterPanelField.java
@@ -19,7 +19,7 @@ public class FilterPanelField extends UiPart<Region> {
     private static final String FXML = "FilterPanelField.fxml";
 
     private final List<String> currentKeywords;
-    private final KeywordsUpdatedHandler onKeywordsUpdated;
+    private final KeywordsChangedHandler onKeywordsChanged;
 
     @FXML
     private Label titleLabel;
@@ -35,16 +35,16 @@ public class FilterPanelField extends UiPart<Region> {
      *
      * @param title The title of this filter field, e.g. "Search by Name".
      * @param promptText The prompt text to show in the keyword input field, e.g. "E.g: Alex".
-     * @param onKeywordsUpdated The callback to trigger when the keywords in this field are updated. The implementation
-     *                          of this callback is defined in {@code FilterPanel}.
+     * @param onKeywordsChanged The method that runs when the keywords are updated from the UI are. The
+     *                          implementation of this method is defined in {@code FilterPanel}.
      */
-    public FilterPanelField(String title, String promptText, KeywordsUpdatedHandler onKeywordsUpdated) {
+    public FilterPanelField(String title, String promptText, KeywordsChangedHandler onKeywordsChanged) {
         super(FXML);
         requireNonNull(title);
         requireNonNull(promptText);
-        requireNonNull(onKeywordsUpdated);
+        requireNonNull(onKeywordsChanged);
 
-        this.onKeywordsUpdated = onKeywordsUpdated;
+        this.onKeywordsChanged = onKeywordsChanged;
         this.currentKeywords = new ArrayList<>();
 
         titleLabel.setText(title);
@@ -64,12 +64,16 @@ public class FilterPanelField extends UiPart<Region> {
     /**
      * Handler for when the user presses the Enter key in the keyword input field.
      *
-     * It adds the keyword, re-renders the FlowPane tags, triggers the
-     * {@code onKeywordsUpdated} callback, and finally clears the keyword input field.
+     * It adds the keyword, re-render the FlowPane tags, trigger the
+     * {@code onKeywordsChanged} event handler, and finally clears the keyword input field.
      */
     @FXML
-    private void handleKeywordSubmitted() {
-        String trimmedKeyword = keywordInputField.getText().trim();
+    private void handleFieldEntered() {
+        String keyword = keywordInputField.getText();
+        requireNonNull(keyword);
+
+        String trimmedKeyword = keyword.trim();
+
         if (trimmedKeyword.isEmpty() || currentKeywords.contains(trimmedKeyword)) {
             keywordInputField.clear();
             return;
@@ -79,14 +83,14 @@ public class FilterPanelField extends UiPart<Region> {
         List<String> proposedKeywords = new ArrayList<>(currentKeywords);
         proposedKeywords.add(trimmedKeyword);
 
-        // validate user input with #onKeywordsUpdated
-        List<String> validatedKeywords = onKeywordsUpdated.onKeywordsUpdated(proposedKeywords);
+        // validate user input with #onKeywordsChanged
+        List<String> validatedKeywords = onKeywordsChanged.handle(proposedKeywords);
         applyValidatedKeywords(validatedKeywords);
 
         keywordInputField.clear();
     }
 
-    // Replaces the current keywords with the validated keywords, then redraws the FlowPane tags.
+    // Replaces the current keywords with the validated keywords, then redraws the FlowPane tags
     private void applyValidatedKeywords(List<String> validatedKeywords) {
         currentKeywords.clear();
 
@@ -108,7 +112,7 @@ public class FilterPanelField extends UiPart<Region> {
         if (!proposedKeywords.remove(tagToDelete)) {
             return;
         }
-        List<String> validatedKeywords = onKeywordsUpdated.onKeywordsUpdated(List.copyOf(proposedKeywords));
+        List<String> validatedKeywords = onKeywordsChanged.handle(List.copyOf(proposedKeywords));
         applyValidatedKeywords(validatedKeywords);
     }
 
@@ -116,7 +120,7 @@ public class FilterPanelField extends UiPart<Region> {
      * Handler for when the keywords in this field are edited.
      */
     @FunctionalInterface
-    public interface KeywordsUpdatedHandler {
-        List<String> onKeywordsUpdated(List<String> keywords);
+    public interface KeywordsChangedHandler {
+        List<String> handle(List<String> keywords);
     }
 }

--- a/src/main/resources/view/FilterPanelField.fxml
+++ b/src/main/resources/view/FilterPanelField.fxml
@@ -10,7 +10,7 @@
 <VBox spacing="5.0" xmlns="http://javafx.com/javafx/17.0.12" xmlns:fx="http://javafx.com/fxml/1">
     <children>
         <Label fx:id="titleLabel" styleClass="label-bright" stylesheets="@DarkTheme.css" text="Search by Field"/>
-        <TextField fx:id="keywordInputField" onAction="#handleKeywordSubmitted" promptText="E.g: Field example"/>
+        <TextField fx:id="keywordInputField" onAction="#handleFieldEntered" promptText="E.g: Field example"/>
         <HBox>
             <children>
                 <Label fx:id="keywordsLabel" minWidth="57.0" styleClass="label-small" text="Keywords:"/>


### PR DESCRIPTION
## Bug in Find Command GUI
* When more than 10 tags are added for a certain field, user should not be able to add new tags in the UI
* However, since there is no logic doing tag validation from the UI, new tags are still created despite the error.

## Bug fix
* Updated the keyword addition and deletion logic in `FilterPanelField` so that every change (add or remove) is validated via the callback to FilterDetails (where the 'no-more-than-10-keywords' error is thrown), and the UI is updated to the validated set of keywords
* Conduct code quality to ensure adhrence in method naming and java conventions

* Fixes #219 