### PR TITLE
Bug: Resolve Javafx logger error

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,7 +49,7 @@ task coverage(type: JacocoReport) {
 
 dependencies {
     String jUnitVersion = '5.4.0'
-    String javaFxVersion = '17.0.7'
+    String javaFxVersion = '17.0.12'
 
     implementation group: 'org.openjfx', name: 'javafx-base', version: javaFxVersion, classifier: 'win'
     implementation group: 'org.openjfx', name: 'javafx-base', version: javaFxVersion, classifier: 'mac'


### PR DESCRIPTION
The logger always give us this warning about:

```
mar. 28, 2026 3:49:32 P. M. javafx.fxml.FXMLLoader$ValueElement processValue
WARNING: Loading FXML document with JavaFX API of version 17.0.12 by JavaFX runtime of version 17.0.7
```
The remedy is simple:
* Change javaFxVersion to javaFxVersion = '17.0.12'
* No bugs in the UI are observed after the change

* Fixes #230 