### PR TITLE
Display selected resident demerit records in details tab

### DIFF
--- a/src/main/java/seedu/address/ui/tab/DemeritRecords.java
+++ b/src/main/java/seedu/address/ui/tab/DemeritRecords.java
@@ -1,6 +1,19 @@
 package seedu.address.ui.tab;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import javafx.beans.property.SimpleStringProperty;
+import javafx.beans.value.ObservableValue;
+import javafx.fxml.FXML;
+import javafx.scene.control.ContentDisplay;
+import javafx.scene.control.TableCell;
+import javafx.scene.control.TableColumn;
+import javafx.scene.control.TableView;
 import javafx.scene.layout.Region;
+import javafx.scene.text.Text;
+import seedu.address.model.demerit.DemeritIncident;
+import seedu.address.model.person.Person;
 import seedu.address.ui.UiPart;
 
 /**
@@ -10,7 +23,163 @@ public class DemeritRecords extends UiPart<Region> {
 
     private static final String FXML = "DemeritRecords.fxml";
 
-    public DemeritRecords() {
+    private static final String BODY_CELL_STYLE =
+            "-fx-background-color: #2b2b2b; "
+                    + "-fx-border-color: #555555; "
+                    + "-fx-text-fill: white;";
+
+    private static final String WRAPPED_TEXT_STYLE =
+            "-fx-fill: white;";
+
+    private final ObservableValue<Person> selectedPerson;
+
+    @FXML
+    private TableView<DemeritRecordRow> demeritTableView;
+
+    @FXML
+    private TableColumn<DemeritRecordRow, String> indexColumn;
+
+    @FXML
+    private TableColumn<DemeritRecordRow, String> descriptionColumn;
+
+    @FXML
+    private TableColumn<DemeritRecordRow, String> remarkColumn;
+
+    @FXML
+    private TableColumn<DemeritRecordRow, String> pointsColumn;
+
+    /**
+     * Creates a {@code DemeritRecords} component bound to the selected person.
+     */
+    public DemeritRecords(ObservableValue<Person> selectedPerson) {
         super(FXML);
+        this.selectedPerson = selectedPerson;
+        initialiseColumns();
+        bindSelectionListener();
+        updateTable(selectedPerson.getValue());
+    }
+
+    /**
+     * Sets up the table columns.
+     */
+    private void initialiseColumns() {
+        indexColumn.setCellValueFactory(cellData ->
+                new SimpleStringProperty(cellData.getValue().index()));
+
+        descriptionColumn.setCellValueFactory(cellData ->
+                new SimpleStringProperty(cellData.getValue().description()));
+
+        remarkColumn.setCellValueFactory(cellData ->
+                new SimpleStringProperty(cellData.getValue().remark()));
+
+        pointsColumn.setCellValueFactory(cellData ->
+                new SimpleStringProperty(cellData.getValue().points()));
+
+        indexColumn.setCellFactory(column -> createCenteredCell());
+        pointsColumn.setCellFactory(column -> createCenteredCell());
+        descriptionColumn.setCellFactory(column -> createWrappingCell());
+        remarkColumn.setCellFactory(column -> createWrappingCell());
+    }
+
+    /**
+     * Creates a table cell that wraps long text instead of truncating it with ellipsis.
+     */
+    private TableCell<DemeritRecordRow, String> createWrappingCell() {
+        return new TableCell<>() {
+            private final Text text = new Text();
+
+            {
+                text.wrappingWidthProperty().bind(widthProperty().subtract(16));
+                text.setStyle(WRAPPED_TEXT_STYLE);
+                setGraphic(text);
+                setContentDisplay(ContentDisplay.GRAPHIC_ONLY);
+                setPrefHeight(Region.USE_COMPUTED_SIZE);
+            }
+
+            @Override
+            protected void updateItem(String item, boolean empty) {
+                super.updateItem(item, empty);
+
+                if (empty || item == null) {
+                    text.setText(null);
+                    setGraphic(null);
+                    setStyle("");
+                } else {
+                    text.setText(item);
+                    setGraphic(text);
+                    setStyle(BODY_CELL_STYLE);
+                }
+            }
+        };
+    }
+
+    /**
+     * Creates a centered white-text cell for short values such as index and points.
+     */
+    private TableCell<DemeritRecordRow, String> createCenteredCell() {
+        return new TableCell<>() {
+            @Override
+            protected void updateItem(String item, boolean empty) {
+                super.updateItem(item, empty);
+
+                if (empty || item == null) {
+                    setText(null);
+                    setGraphic(null);
+                    setStyle("");
+                } else {
+                    setText(item);
+                    setStyle(BODY_CELL_STYLE + " -fx-alignment: CENTER; -fx-text-fill: white;");
+                }
+            }
+        };
+    }
+
+    /**
+     * Updates the table whenever the selected person changes.
+     */
+    private void bindSelectionListener() {
+        selectedPerson.addListener((observable, oldValue, newValue) -> updateTable(newValue));
+    }
+
+    /**
+     * Rebuilds the table rows for the given person.
+     */
+    private void updateTable(Person person) {
+        demeritTableView.getItems().clear();
+
+        if (person == null) {
+            return;
+        }
+
+        List<DemeritRecordRow> rows = new ArrayList<>();
+        List<DemeritIncident> incidents = person.getDemeritIncidents();
+
+        for (int i = 0; i < incidents.size(); i++) {
+            DemeritIncident incident = incidents.get(i);
+            rows.add(new DemeritRecordRow(
+                    String.valueOf(i + 1),
+                    formatDescription(incident),
+                    incident.getRemark(),
+                    "+" + incident.getPointsApplied()
+            ));
+        }
+
+        demeritTableView.getItems().setAll(rows);
+    }
+
+    /**
+     * Formats a readable description for one demerit incident.
+     */
+    private String formatDescription(DemeritIncident incident) {
+        return String.format("[%d] %s (offence %d)",
+                incident.getRuleIndex(),
+                incident.getRuleTitle(),
+                incident.getOffenceNumber());
+    }
+
+    /**
+     * Table row model for demerit records.
+     */
+    private record DemeritRecordRow(String index, String description, String remark, String points) {
     }
 }

--- a/src/main/java/seedu/address/ui/tab/StudentDetailsTab.java
+++ b/src/main/java/seedu/address/ui/tab/StudentDetailsTab.java
@@ -14,11 +14,12 @@ import seedu.address.ui.UiPart;
 public class StudentDetailsTab extends UiPart<Region> {
 
     private static final String FXML = "StudentDetailsTab.fxml";
+
     /**
-     * The person whose details would be shown in the directory tab
-     **/
-    // TODO: Implement selectedPerson logic
+     * The person whose details would be shown in the directory tab.
+     */
     private final ObservableValue<Person> selectedPerson;
+
     @FXML
     private TabPane studentDetailsTabPane;
 
@@ -29,7 +30,7 @@ public class StudentDetailsTab extends UiPart<Region> {
     private StackPane demeritRecordsPlaceholder;
 
     /**
-     * Creates a {@code StudentDetailsTab} with the given {@code Logic}.
+     * Creates a {@code StudentDetailsTab} with the selected person observable.
      */
     public StudentDetailsTab(ObservableValue<Person> selectedPerson) {
         super(FXML);
@@ -41,7 +42,7 @@ public class StudentDetailsTab extends UiPart<Region> {
         Profile profile = new Profile(selectedPerson);
         profilePlaceholder.getChildren().add(profile.getRoot());
 
-        DemeritRecords demeritRecords = new DemeritRecords();
+        DemeritRecords demeritRecords = new DemeritRecords(selectedPerson);
         demeritRecordsPlaceholder.getChildren().add(demeritRecords.getRoot());
     }
 }

--- a/src/main/resources/view/DemeritRecords.fxml
+++ b/src/main/resources/view/DemeritRecords.fxml
@@ -1,32 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<?import javafx.scene.control.*?>
-<?import javafx.scene.layout.*?>
+<?import javafx.scene.control.TableColumn?>
+<?import javafx.scene.control.TableView?>
+<?import javafx.scene.layout.VBox?>
 
-<ScrollPane fitToHeight="true" fitToWidth="true" vbarPolicy="AS_NEEDED" hbarPolicy="NEVER"
-            styleClass="undecorated-scroll-pane"
-            stylesheets="@DarkTheme.css" xmlns="http://javafx.com/javafx/17.0.12" xmlns:fx="http://javafx.com/fxml/1">
-   <content>
-      <VBox prefWidth="439.0" spacing="10" styleClass="panel-container">
+<VBox xmlns="http://javafx.com/javafx/17"
+      xmlns:fx="http://javafx.com/fxml/1"
+      spacing="10"
+      styleClass="panel-container"
+      stylesheets="@DarkTheme.css">
 
-          <Label styleClass="panel-heading" text="Demerit Records" />
+    <TableView fx:id="demeritTableView" styleClass="custom-table" VBox.vgrow="ALWAYS">
+        <columns>
+            <TableColumn fx:id="indexColumn" prefWidth="50.0" text="#" />
+            <TableColumn fx:id="descriptionColumn" prefWidth="360.0" text="Description" />
+            <TableColumn fx:id="remarkColumn" prefWidth="260.0" text="Remark" />
+            <TableColumn fx:id="pointsColumn" prefWidth="80.0" text="Points" />
+        </columns>
+        <columnResizePolicy>
+            <TableView fx:constant="CONSTRAINED_RESIZE_POLICY" />
+        </columnResizePolicy>
+    </TableView>
 
-          <TableView fx:id="demeritTableView" styleClass="custom-table" VBox.vgrow="ALWAYS">
-              <columns>
-                  <TableColumn fx:id="indexColumn" prefWidth="40.0" text="#" />
-                  <TableColumn fx:id="dateColumn" prefWidth="100.0" text="Date" />
-                  <TableColumn fx:id="descriptionColumn" prefWidth="250.0" text="Description" />
-                  <TableColumn fx:id="severityColumn" prefWidth="75.0" text="Severity" />
-              </columns>
-              <columnResizePolicy>
-                  <TableView fx:constant="CONSTRAINED_RESIZE_POLICY" />
-              </columnResizePolicy>
-          </TableView>
-
-          <HBox alignment="CENTER_RIGHT" fillHeight="false">
-              <Button styleClass="btn-danger" text="Delete Selected" />
-          </HBox>
-
-      </VBox>
-   </content>
-</ScrollPane>
+</VBox>


### PR DESCRIPTION
Fixes #250 

### Summary
- display demerit incidents for the currently selected resident in the demerit records tab
- add a dedicated remark column to the records table
- improve table readability by wrapping long description and remark text
- increase contrast for demerit-table content without affecting the global theme

### Testing
- ./gradlew compileJava
- ./gradlew check
- ./gradlew clean test
- manually verified demerit records update correctly for the selected resident