### PR TITLE
Show delete confirmation only for existing residents

### DIFF
--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -29,11 +29,19 @@ public class DeleteCommand extends Command {
 
     /**
      * Constructor to initialize studentId
+     *
      * @param targetStudentId the studentId of the student to be deleted
      */
     public DeleteCommand(StudentId targetStudentId) {
         requireNonNull(targetStudentId);
         this.targetStudentId = targetStudentId;
+    }
+
+    /**
+     * Returns the student ID targeted for deletion.
+     */
+    public StudentId getTargetStudentId() {
+        return targetStudentId;
     }
 
     @Override

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -197,11 +197,15 @@ public class MainWindow extends UiPart<Stage> {
      */
     private CommandResult executeCommand(String commandText) throws CommandException, ParseException {
         try {
-            if (isDeleteCommand(commandText) && !showDeleteConfirmationDialog()) {
-                CommandResult cancelResult = new CommandResult(MESSAGE_DELETE_CANCELLED);
-                logger.info("Result: " + cancelResult.getFeedbackToUser());
-                resultDisplay.setFeedbackToUser(cancelResult.getFeedbackToUser());
-                return cancelResult;
+            Optional<DeleteCommand> deleteCommand = parseDeleteCommand(commandText);
+
+            if (deleteCommand.isPresent() && deleteTargetExists(deleteCommand.get())) {
+                if (!showDeleteConfirmationDialog()) {
+                    CommandResult cancelResult = new CommandResult(MESSAGE_DELETE_CANCELLED);
+                    logger.info("Result: " + cancelResult.getFeedbackToUser());
+                    resultDisplay.setFeedbackToUser(cancelResult.getFeedbackToUser());
+                    return cancelResult;
+                }
             }
 
             CommandResult commandResult = logic.execute(commandText);
@@ -225,14 +229,26 @@ public class MainWindow extends UiPart<Stage> {
     }
 
     /**
-     * Returns true if the given command text is a valid DeleteCommand.
+     * Returns the parsed {@code DeleteCommand} if the command text is a valid delete command.
+     * Returns {@code Optional.empty()} otherwise.
      */
-    private boolean isDeleteCommand(String commandText) {
+    private Optional<DeleteCommand> parseDeleteCommand(String commandText) {
         try {
-            return new AddressBookParser().parseCommand(commandText) instanceof DeleteCommand;
+            if (new AddressBookParser().parseCommand(commandText) instanceof DeleteCommand deleteCommand) {
+                return Optional.of(deleteCommand);
+            }
+            return Optional.empty();
         } catch (ParseException e) {
-            return false;
+            return Optional.empty();
         }
+    }
+
+    /**
+     * Returns true if the delete command targets an existing resident.
+     */
+    private boolean deleteTargetExists(DeleteCommand deleteCommand) {
+        return logic.getAddressBook().getPersonList().stream()
+                .anyMatch(person -> person.getStudentId().equals(deleteCommand.getTargetStudentId()));
     }
 
     /**


### PR DESCRIPTION
Fixes #243 

### Summary
- validate delete target before showing confirmation dialog
- only show confirmation for existing residents
- allow invalid or non-existent delete targets to fail immediately with an error

### Testing
- ./gradlew compileJava
- ./gradlew check
- ./gradlew clean test
- manually verified confirmation dialog no longer appears for invalid/non-existent student IDs