### PR TITLE
Rename demerit index parser method

### DIFF
--- a/src/main/java/seedu/address/logic/parser/DemeritCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DemeritCommandParser.java
@@ -1,5 +1,6 @@
 package seedu.address.logic.parser;
 
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_DEMERIT_INDEX;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_REMARK;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_STUDENT_ID;
@@ -9,7 +10,7 @@ import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.StudentId;
 
 /**
- * Parses input arguments and creates a new DemeritCommand object.
+ * Parses input arguments and creates a new {@code DemeritCommand} object.
  */
 public class DemeritCommandParser implements Parser<DemeritCommand> {
 
@@ -20,22 +21,17 @@ public class DemeritCommandParser implements Parser<DemeritCommand> {
      * @throws ParseException if the user input does not conform the expected format
      */
     public DemeritCommand parse(String args) throws ParseException {
-        ParserUtil.checkForUnknownPrefixes(args, DemeritCommand.MESSAGE_USAGE, PREFIX_STUDENT_ID,
-                PREFIX_DEMERIT_INDEX, PREFIX_REMARK);
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_STUDENT_ID, PREFIX_DEMERIT_INDEX, PREFIX_REMARK);
 
-        if (!argMultimap.arePrefixesPresent(PREFIX_STUDENT_ID, PREFIX_DEMERIT_INDEX)
+        if (!argMultimap.getValue(PREFIX_STUDENT_ID).isPresent()
+                || !argMultimap.getValue(PREFIX_DEMERIT_INDEX).isPresent()
                 || !argMultimap.getPreamble().isEmpty()) {
-            throw new ParseException(DemeritCommand.MESSAGE_USAGE);
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, DemeritCommand.MESSAGE_USAGE));
         }
 
-        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_STUDENT_ID, PREFIX_DEMERIT_INDEX, PREFIX_REMARK);
-
-        StudentId studentId = ParserUtil.parseStudentId(
-                argMultimap.getValue(PREFIX_STUDENT_ID).get());
-        int ruleIndex = ParserUtil.parsePositiveInt(
-                argMultimap.getValue(PREFIX_DEMERIT_INDEX).get());
+        StudentId studentId = ParserUtil.parseStudentId(argMultimap.getValue(PREFIX_STUDENT_ID).get());
+        int ruleIndex = ParserUtil.parseDemeritIndex(argMultimap.getValue(PREFIX_DEMERIT_INDEX).get());
         String remark = argMultimap.getValue(PREFIX_REMARK).orElse("");
 
         return new DemeritCommand(studentId, ruleIndex, remark);

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -168,7 +168,7 @@ public class ParserUtil {
      *
      * @throws ParseException if the given {@code input} is not a positive integer.
      */
-    public static int parsePositiveInt(String input) throws ParseException {
+    public static int parseDemeritIndex(String input) throws ParseException {
         requireNonNull(input);
         String trimmedInput = input.trim();
         try {


### PR DESCRIPTION
Fixes #314

### Summary
- rename `parsePositiveInt` to `parseDemeritIndex` in `ParserUtil`
- update `DemeritCommandParser` to use the clearer method name

### Testing
- ./gradlew compileJava
- ./gradlew check
- ./gradlew clean test