### PR TITLE
Show total demerit points in demerit tab

### DIFF
--- a/src/main/java/seedu/address/ui/tab/DemeritRecords.java
+++ b/src/main/java/seedu/address/ui/tab/DemeritRecords.java
@@ -7,6 +7,7 @@ import javafx.beans.property.SimpleStringProperty;
 import javafx.beans.value.ObservableValue;
 import javafx.fxml.FXML;
 import javafx.scene.control.ContentDisplay;
+import javafx.scene.control.Label;
 import javafx.scene.control.TableCell;
 import javafx.scene.control.TableColumn;
 import javafx.scene.control.TableView;
@@ -22,8 +23,12 @@ import seedu.address.ui.UiPart;
 public class DemeritRecords extends UiPart<Region> {
 
     private static final String FXML = "DemeritRecords.fxml";
+    private static final String TOTAL_POINTS_LABEL_PREFIX = "Total Demerit Points: ";
 
     private final ObservableValue<Person> selectedPerson;
+
+    @FXML
+    private Label totalPointsLabel;
 
     @FXML
     private TableView<DemeritRecordRow> demeritTableView;
@@ -48,7 +53,7 @@ public class DemeritRecords extends UiPart<Region> {
         this.selectedPerson = selectedPerson;
         initialiseColumns();
         bindSelectionListener();
-        updateTable(selectedPerson.getValue());
+        updateView(selectedPerson.getValue());
     }
 
     /**
@@ -128,10 +133,26 @@ public class DemeritRecords extends UiPart<Region> {
     }
 
     /**
-     * Updates the table whenever the selected person changes.
+     * Updates the view whenever the selected person changes.
      */
     private void bindSelectionListener() {
-        selectedPerson.addListener((observable, oldValue, newValue) -> updateTable(newValue));
+        selectedPerson.addListener((observable, oldValue, newValue) -> updateView(newValue));
+    }
+
+    /**
+     * Updates both the total points summary and the incident table.
+     */
+    private void updateView(Person person) {
+        updateTotalPointsLabel(person);
+        updateTable(person);
+    }
+
+    /**
+     * Updates the total demerit points label for the selected person.
+     */
+    private void updateTotalPointsLabel(Person person) {
+        int totalPoints = person == null ? 0 : person.getTotalDemeritPoints();
+        totalPointsLabel.setText(TOTAL_POINTS_LABEL_PREFIX + totalPoints);
     }
 
     /**

--- a/src/main/resources/view/DemeritRecords.css
+++ b/src/main/resources/view/DemeritRecords.css
@@ -12,3 +12,10 @@
 .demerit-record-wrapped-text {
     -fx-fill: white;
 }
+
+.demerit-total-points-label {
+    -fx-text-fill: white;
+    -fx-font-size: 14px;
+    -fx-font-weight: bold;
+    -fx-padding: 4px 0 2px 0;
+}

--- a/src/main/resources/view/DemeritRecords.fxml
+++ b/src/main/resources/view/DemeritRecords.fxml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
+<?import javafx.scene.control.Label?>
 <?import javafx.scene.control.TableColumn?>
 <?import javafx.scene.control.TableView?>
 <?import javafx.scene.layout.VBox?>
@@ -9,6 +10,8 @@
       spacing="10"
       styleClass="panel-container"
       stylesheets="@DarkTheme.css,@DemeritRecords.css">
+
+    <Label fx:id="totalPointsLabel" styleClass="demerit-total-points-label" />
 
     <TableView fx:id="demeritTableView" styleClass="custom-table" VBox.vgrow="ALWAYS">
         <columns>


### PR DESCRIPTION
Fixes #303

### Summary
- add total accumulated demerit points display to the demerit tab
- keep the total synced with the currently selected resident
- preserve existing demerit records table behavior

### Testing
- ./gradlew compileJava
- ./gradlew test -x jacocoTestReport
- ./gradlew checkstyleMain checkstyleTest
- manually verified total points update with resident selection