### PR TITLE
Bug: Fix unhandled exception when user selects a gender tag not available in filtered list

### DIFF
--- a/src/main/java/seedu/address/ui/filter/AbstractFilterPanelInput.java
+++ b/src/main/java/seedu/address/ui/filter/AbstractFilterPanelInput.java
@@ -101,7 +101,6 @@ public abstract class AbstractFilterPanelInput extends UiPart<Region> {
         // Push proposedKeywords through validation callback and apply the validated result
         List<String> validatedKeywords = onKeywordsChanged.handle(List.copyOf(proposedKeywords));
         applyValidatedKeywords(validatedKeywords);
-        clearInputControl();
     }
 
     /**


### PR DESCRIPTION
Fixes #339 

### Step to replicate:
1. Make it so there is no she/her resident in the filtered list
2. Set 'Search by Gender' in the GUI as 'she/her'

### Error thrown:

<img width="450" alt="Image" src="https://github.com/user-attachments/assets/af13b1ea-7562-4276-884b-50eeeb500322" />

### Error Fix
* Currently, when #tryAddKeyword returns a list of validated keywords, it
 accidentally calls #iclearInputControl(), leading to a bug described in #339
* Upon testing, the error disappears