### PR TITLE
Reject duplicate prefixes in delete parser

### DIFF
--- a/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
@@ -25,6 +25,8 @@ public class DeleteCommandParser implements Parser<DeleteCommand> {
         checkForUnknownPrefixes(args);
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_STUDENT_ID);
 
+        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_STUDENT_ID);
+
         if (!arePrefixesPresent(argMultimap, PREFIX_STUDENT_ID) || !argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
         }

--- a/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
@@ -32,4 +32,10 @@ public class DeleteCommandParserTest {
     public void parse_invalidStudentId_throwsParseException() {
         assertParseFailure(parser, " i=", StudentId.MESSAGE_CONSTRAINTS);
     }
+
+    @Test
+    public void parse_duplicateStudentIdPrefix_throwsParseException() {
+        assertParseFailure(parser, " i=A1234567X i=A7654321X",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
+    }
 }

--- a/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
@@ -1,6 +1,8 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.Messages.getErrorMessageForDuplicatePrefixes;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_STUDENT_ID;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 
@@ -36,6 +38,6 @@ public class DeleteCommandParserTest {
     @Test
     public void parse_duplicateStudentIdPrefix_throwsParseException() {
         assertParseFailure(parser, " i=A1234567X i=A7654321X",
-                String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
+                getErrorMessageForDuplicatePrefixes(PREFIX_STUDENT_ID));
     }
 }


### PR DESCRIPTION
Fixes #472 ambiguous delete inputs by rejecting repeated `i=` prefixes.

Why:
- `delete` should target exactly one student ID
- repeated `i=` prefixes make the command ambiguous
- current behavior silently uses the last value

What changed:
- reject repeated `i=` in `DeleteCommandParser`
- add a parser test for duplicate `i=` input