### PR TITLE
Ui: Fix the white empty void problem

### DIFF
--- a/src/main/resources/view/Profile.fxml
+++ b/src/main/resources/view/Profile.fxml
@@ -1,10 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<?import javafx.geometry.*?>
-<?import javafx.scene.control.*?>
-<?import javafx.scene.layout.*?>
-<ScrollPane fx:id="profile" fitToWidth="true" xmlns="http://javafx.com/javafx/17.0.12" xmlns:fx="http://javafx.com/fxml/1">
-<VBox prefHeight="528.0" prefWidth="476.0" spacing="10" styleClass="panel-container" stylesheets="@DarkTheme.css" xmlns="http://javafx.com/javafx/17.0.12" xmlns:fx="http://javafx.com/fxml/1">
+<?import javafx.geometry.Insets?>
+<?import javafx.scene.control.Label?>
+<?import javafx.scene.control.ScrollPane?>
+<?import javafx.scene.control.TextArea?>
+<?import javafx.scene.control.TextField?>
+<?import javafx.scene.layout.ColumnConstraints?>
+<?import javafx.scene.layout.FlowPane?>
+<?import javafx.scene.layout.GridPane?>
+<?import javafx.scene.layout.RowConstraints?>
+<?import javafx.scene.layout.VBox?>
+<ScrollPane xmlns:fx="http://javafx.com/fxml/1" fx:id="profile" fitToWidth="true" fitToHeight="true" styleClass="background"
+            stylesheets="@DarkTheme.css" xmlns="http://javafx.com/javafx/17.0.12">
+    <VBox xmlns:fx="http://javafx.com/fxml/1" prefWidth="476.0" spacing="10"
+          styleClass="panel-container" xmlns="http://javafx.com/javafx/17.0.12">
     <TextArea fx:id="nameField" prefHeight="45" minHeight="40" editable="false" focusTraversable="false" styleClass="panel-heading" />
     <FlowPane fx:id="tags">
         <VBox.margin>


### PR DESCRIPTION
<img width="200" alt="image" src="https://github.com/user-attachments/assets/cf7d0555-3380-4841-a1e4-05df16021492" />

Fix the empty white void problem.


We need to add fit to width property to the scroll pane

<img width="200" alt="image" src="https://github.com/user-attachments/assets/9a2b74ef-61a7-43ba-9082-a8e897219a03" />
